### PR TITLE
ueventd: update LED sysfs path

### DIFF
--- a/rootdir/ueventd.tone.rc
+++ b/rootdir/ueventd.tone.rc
@@ -126,11 +126,11 @@
 /sys/devices/soc/75b6000.i2c/i2c-8/8-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/soc/leds-qpnp-26/leds/wled:backlight max_brightness     0664 system system
-/sys/devices/soc/leds-qpnp-26/leds/wled:backlight brightness         0664 system system
-/sys/devices/soc/leds-qpnp-25/leds/led:* max_brightness              0664 system system
-/sys/devices/soc/leds-qpnp-25/leds/led:* brightness                  0664 system system
-/sys/devices/soc/leds-qpnp-25/leds/led:* blink                       0664 system system
+/sys/devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d800/leds/wled/brightness      0664 system system
+/sys/devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d800/leds/wled/max_brightness  0664 system system
+/sys/devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
+/sys/devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* brightness     0664 system system
+/sys/devices/soc/400f000.qcom,spmi/spmi-0/spmi0-03/400f000.qcom,spmi:qcom,pmi8994@3:qcom,leds@d000/leds/led:* blink          0664 system system
 /sys/class/leds/lcd-backlight/max_brightness                         0644 root system
 /sys/class/leds/lcd-backlight/brightness                             0664 system system
 


### PR DESCRIPTION
in kernel 4.4 we use a new SPMI driver and paths chaged

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>